### PR TITLE
feat: mark secret properties as secret type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.2.1-SNAPSHOT
-kestraVersion=1.2.3
+kestraVersion=1.3.13

--- a/src/main/java/io/kestra/plugin/prefect/CreateFlowRun.java
+++ b/src/main/java/io/kestra/plugin/prefect/CreateFlowRun.java
@@ -144,7 +144,7 @@ public class CreateFlowRun extends Task implements RunnableTask<CreateFlowRun.Ou
             Authentication sent in the Authorization header. Prefect Cloud expects an API key (sent as Bearer); self-hosted can supply a base64 Basic token like "YWRtaW46cGFzcw==" or the full "Basic ..." header; leave empty for unauthenticated servers.
             """
     )
-    @PluginProperty(group = "connection")
+    @PluginProperty(group = "connection", secret = true)
     private Property<String> apiKey;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/prefect/PrefectConnection.java
+++ b/src/main/java/io/kestra/plugin/prefect/PrefectConnection.java
@@ -4,7 +4,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.models.annotations.PluginProperty;
-import io.kestra.core.models.annotations.Schema;
 import lombok.*;
 
 import java.net.URI;
@@ -21,7 +20,6 @@ public class PrefectConnection {
     @Builder.Default
     private Property<String> apiUrl = Property.ofValue(PREFECT_CLOUD_API_BASE_URL);
 
-    @Schema(title = "Prefect API key", description = "Prefect Cloud API key for authentication.")
     @PluginProperty(secret = true)
     private Property<String> apiKey;
 

--- a/src/main/java/io/kestra/plugin/prefect/PrefectConnection.java
+++ b/src/main/java/io/kestra/plugin/prefect/PrefectConnection.java
@@ -1,14 +1,15 @@
 package io.kestra.plugin.prefect;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.annotations.Schema;
 import lombok.*;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 
 @Builder
 @Getter
@@ -20,7 +21,8 @@ public class PrefectConnection {
     @Builder.Default
     private Property<String> apiUrl = Property.ofValue(PREFECT_CLOUD_API_BASE_URL);
 
-    // Optional: only required for Prefect Cloud (not used in self-hosted)
+    @Schema(title = "Prefect API key", description = "Prefect Cloud API key for authentication.")
+    @PluginProperty(secret = true)
     private Property<String> apiKey;
 
     // Optional: only required for Prefect Cloud


### PR DESCRIPTION
## Summary
- Mark apiKey as secret type in CreateFlowRun and PrefectConnection

Part-of: https://github.com/kestra-io/kestra-ee/issues/7361