### PR TITLE
refactor: replace deprecated tasks and filters

### DIFF
--- a/src/test/resources/flows/prefect-flow-run-async.yaml
+++ b/src/test/resources/flows/prefect-flow-run-async.yaml
@@ -11,7 +11,7 @@ tasks:
     wait: false
 
   - id: log_triggered
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: |
       Prefect flow run triggered (fire-and-forget)!
       Flow Run ID: {{ outputs.trigger_prefect_deployment_async.flowRunId }}

--- a/src/test/resources/flows/prefect-flow-run.yaml
+++ b/src/test/resources/flows/prefect-flow-run.yaml
@@ -15,7 +15,7 @@ tasks:
       timestamp: "{{ now() }}"
 
   - id: log_result
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: |
       Prefect flow run completed successfully!
       Flow Run ID: {{ outputs.trigger_prefect_deployment.flowRunId }}


### PR DESCRIPTION
Replaces deprecated task identifiers and Pebble filters with their current equivalents